### PR TITLE
Fix warning. See WS2-1104.

### DIFF
--- a/webspark_isearch.libraries.yml
+++ b/webspark_isearch.libraries.yml
@@ -4,7 +4,8 @@ isearch:
   js:
     node_modules/asu-react-isearch-view/dist/drupalIsearchViewer.js: { weight: -5 }
   css:
-    css/clas_isearch_view.css: {}
+    theme:
+      css/clas_isearch_view.css: {}
   dependencies:
     - core/jquery
     - core/drupalSettings


### PR DESCRIPTION
Fixed this warning:
Warning: assert(): Invalid CSS category: css/clas_isearch_view.css. See https://www.drupal.org/node/2274843. failed in Drupal\Core\Asset\LibraryDiscoveryParser->buildByExtension() (line 159 of /var/www/html/web/core/lib/Drupal/Core/Asset/LibraryDiscoveryParser.php)